### PR TITLE
Iterative lookup prototyping

### DIFF
--- a/dns-resolver.cabal
+++ b/dns-resolver.cabal
@@ -25,6 +25,7 @@ library
                        base >=4.13 && <5
                      , bytestring
                      , transformers
+                     , random
                      , iproute
                      , dns
   hs-source-dirs:      src

--- a/dns-resolver.cabal
+++ b/dns-resolver.cabal
@@ -34,3 +34,15 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
+
+Test-Suite query-test
+  type:                exitcode-stdio-1.0
+  other-modules:       QuerySpec
+  main-is:             qtest.hs
+  build-depends:       base
+                     , hspec
+                     , dns
+                     , dns-resolver
+  hs-source-dirs:      qtest
+  default-language:    Haskell2010
+  ghc-options:         -Wall

--- a/dns-resolver.cabal
+++ b/dns-resolver.cabal
@@ -25,6 +25,7 @@ library
                        base >=4.13 && <5
                      , bytestring
                      , transformers
+                     , iproute
                      , dns
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/dns-resolver.cabal
+++ b/dns-resolver.cabal
@@ -19,10 +19,13 @@ extra-source-files:  CHANGELOG.md
 
 library
   exposed-modules:
-  -- other-modules:
-  -- other-extensions:
+                       DNSC.Iterative
+
+  other-modules:
+                       DNSC.RootServers
+
   build-depends:
-                       base >=4.13 && <5
+                       base >=4 && <5
                      , bytestring
                      , transformers
                      , random

--- a/qtest/QuerySpec.hs
+++ b/qtest/QuerySpec.hs
@@ -11,52 +11,61 @@ import DNSC.Iterative (runQuery, runQuery1, runIterative, rootNS)
 spec :: Spec
 spec = describe "query" $ do
 
+  let printQueryError :: Show e => Either e a -> IO ()
+      printQueryError = either (putStrLn . ("    QueryError: " ++) . show) (const $ pure ())
+
   it "rootNS" $ do
     let sp p = case p of (_,_) -> True  -- check not error
     rootNS `shouldSatisfy` sp
 
   it "iterative" $ do
-    let domain = "iij.ad.jp."
-    result <- runIterative rootNS domain
+    result <- runIterative rootNS "iij.ad.jp."
+    printQueryError result
     result `shouldSatisfy` isRight
 
   it "iterative - long" $ do
-    let domain = "c.b.a.pt.dns-oarc.net."
-    result <- runIterative rootNS domain
+    result <- runIterative rootNS "c.b.a.pt.dns-oarc.net."
+    printQueryError result
     result `shouldSatisfy` isRight
 
   it "query1 - ns" $ do
     result <- runQuery1 "iij.ad.jp." NS
+    printQueryError result
     isRight result `shouldBe` True
     let Right msg = result
     length (DNS.answer msg) `shouldSatisfy` (> 0)
 
   it "query1 - a" $ do
     result <- runQuery1 "iij.ad.jp." A
+    printQueryError result
     isRight result `shouldBe` True
     let Right msg = result
     length (DNS.answer msg) `shouldSatisfy` (> 0)
 
   it "query1 - aaaa" $ do
     result <- runQuery1 "iij.ad.jp." AAAA
+    printQueryError result
     isRight result `shouldBe` True
     let Right msg = result
     length (DNS.answer msg) `shouldSatisfy` (> 0)
 
   it "query1 - mx" $ do
     result <- runQuery1 "iij.ad.jp." MX
+    printQueryError result
     isRight result `shouldBe` True
     let Right msg = result
     length (DNS.answer msg) `shouldSatisfy` (> 0)
 
   it "query1 - cname" $ do
     result <- runQuery1 "porttest.dns-oarc.net." CNAME
+    printQueryError result
     isRight result `shouldBe` True
     let Right msg = result
     length (DNS.answer msg) `shouldSatisfy` (> 0)
 
   it "query - a" $ do
     result <- runQuery "porttest.dns-oarc.net." TXT
+    printQueryError result
     isRight result `shouldBe` True
     let Right msg = result
     length (DNS.answer msg) `shouldSatisfy` (> 0)

--- a/qtest/QuerySpec.hs
+++ b/qtest/QuerySpec.hs
@@ -1,0 +1,62 @@
+module QuerySpec where
+
+import Test.Hspec
+
+import Data.Either (isRight)
+import Network.DNS (TYPE(NS, A, AAAA, MX, CNAME, TXT))
+import qualified Network.DNS as DNS
+
+import DNSC.Iterative (runQuery, runQuery1, runIterative, rootNS)
+
+spec :: Spec
+spec = describe "query" $ do
+
+  it "rootNS" $ do
+    let sp p = case p of (_,_) -> True  -- check not error
+    rootNS `shouldSatisfy` sp
+
+  it "iterative" $ do
+    let domain = "iij.ad.jp."
+    result <- runIterative rootNS domain
+    result `shouldSatisfy` isRight
+
+  it "iterative - long" $ do
+    let domain = "c.b.a.pt.dns-oarc.net."
+    result <- runIterative rootNS domain
+    result `shouldSatisfy` isRight
+
+  it "query1 - ns" $ do
+    result <- runQuery1 "iij.ad.jp." NS
+    isRight result `shouldBe` True
+    let Right msg = result
+    length (DNS.answer msg) `shouldSatisfy` (> 0)
+
+  it "query1 - a" $ do
+    result <- runQuery1 "iij.ad.jp." A
+    isRight result `shouldBe` True
+    let Right msg = result
+    length (DNS.answer msg) `shouldSatisfy` (> 0)
+
+  it "query1 - aaaa" $ do
+    result <- runQuery1 "iij.ad.jp." AAAA
+    isRight result `shouldBe` True
+    let Right msg = result
+    length (DNS.answer msg) `shouldSatisfy` (> 0)
+
+  it "query1 - mx" $ do
+    result <- runQuery1 "iij.ad.jp." MX
+    isRight result `shouldBe` True
+    let Right msg = result
+    length (DNS.answer msg) `shouldSatisfy` (> 0)
+
+  it "query1 - cname" $ do
+    result <- runQuery1 "porttest.dns-oarc.net." CNAME
+    isRight result `shouldBe` True
+    let Right msg = result
+    length (DNS.answer msg) `shouldSatisfy` (> 0)
+
+  it "query - a" $ do
+    result <- runQuery "porttest.dns-oarc.net." TXT
+    isRight result `shouldBe` True
+    let Right msg = result
+    length (DNS.answer msg) `shouldSatisfy` (> 0)

--- a/qtest/QuerySpec.hs
+++ b/qtest/QuerySpec.hs
@@ -5,11 +5,17 @@ import Test.Hspec
 import Data.Either (isRight)
 import Network.DNS (TYPE(NS, A, AAAA, MX, CNAME, TXT))
 import qualified Network.DNS as DNS
+import System.Environment (lookupEnv)
 
-import DNSC.Iterative (runQuery, runQuery1, runIterative, rootNS)
+import DNSC.Iterative (runDNSQuery, query, query1, iterative, rootNS)
 
 spec :: Spec
 spec = describe "query" $ do
+  disableV6NS <- runIO $ maybe False ((== "1") . take 1) <$> lookupEnv "DISABLE_V6_NS"
+
+  let runIterative ns n = runDNSQuery (iterative ns n) False disableV6NS
+      runQuery1 n ty = runDNSQuery (query1 n ty) False disableV6NS
+      runQuery n ty = runDNSQuery (query n ty) False disableV6NS
 
   let printQueryError :: Show e => Either e a -> IO ()
       printQueryError = either (putStrLn . ("    QueryError: " ++) . show) (const $ pure ())

--- a/qtest/qtest.hs
+++ b/qtest/qtest.hs
@@ -1,0 +1,6 @@
+import Test.Hspec
+
+import QuerySpec (spec)
+
+main :: IO ()
+main = hspec spec

--- a/src/DNSC/Iterative.hs
+++ b/src/DNSC/Iterative.hs
@@ -149,7 +149,7 @@ query1 n typ = do
   lift $ traceLn $ "query1: " ++ show (n, typ)
   nss <- iterative rootNS n
   sa <- selectAuthNS nss
-  msg <- dnsQueryT $ const $ qNorec1 sa (B8.pack n) typ
+  msg <- dnsQueryT $ const $ norec1 sa (B8.pack n) typ
   lift $ mapM_ cacheRR $ DNS.answer msg
   return msg
 
@@ -188,7 +188,7 @@ iterative_ nss (x:xs) =
     step nss_ = do
       sa <- selectAuthNS nss_  -- 親ドメインから同じ NS の情報が引き継がれた場合も、NS のアドレスを選択しなおすことで balancing する.
       lift $ traceLn $ "iterative: " ++ show (sa, name)
-      msg <- dnsQueryT $ const $ qNorec1 sa name A
+      msg <- dnsQueryT $ const $ norec1 sa name A
       pure $ authorityNS name msg
 
 -- 選択可能な NS が有るときだけ Just
@@ -206,8 +206,8 @@ authorityNS_ dom auths adds =
       | rrname rr == dom  =  Just (ns, rr)
     takeNS _              =  Nothing
 
-qNorec1 :: IP -> Domain -> TYPE -> IO (Either DNSError DNSMessage)
-qNorec1 aserver name typ = do
+norec1 :: IP -> Domain -> TYPE -> IO (Either DNSError DNSMessage)
+norec1 aserver name typ = do
   rs <- DNS.makeResolvSeed conf
   DNS.withResolver rs $ \resolver -> DNS.lookupRaw resolver name typ
   where

--- a/src/DNSC/Iterative.hs
+++ b/src/DNSC/Iterative.hs
@@ -5,7 +5,6 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Maybe (MaybeT (..))
 import Control.Monad.Trans.Except (ExceptT (..), runExceptT, throwE)
--- import Data.Monoid (Last (..))
 import qualified Data.ByteString.Char8 as B8
 import Data.Maybe (mapMaybe, listToMaybe)
 import Data.List (isSuffixOf, unfoldr, intercalate)
@@ -69,16 +68,6 @@ rootServers =
   ]
 
 -----
-
-{-
-type Error = Last DNSError
-
-dnsError :: DNSError -> Error
-dnsError = Last . Just
-
-mapDnsError :: Either DNSError a -> Either Error a
-mapDnsError = either (Left . dnsError) Right
- -}
 
 type DNSQuery = ExceptT DNSError IO
 

--- a/src/DNSC/Iterative.hs
+++ b/src/DNSC/Iterative.hs
@@ -129,7 +129,9 @@ query1 n typ = do
   when debug $ liftIO $ putStrLn $ "query1: " ++ show (n, typ)
   roota <- maybe (throwE DNS.BadConfiguration) pure =<< liftIO selectRoot
   sa <- iterative roota n
-  ExceptT $ qNorec1 sa (B8.pack n) typ
+  msg <- ExceptT $ qNorec1 sa (B8.pack n) typ
+  liftIO $ mapM_ cacheRR $ DNS.answer msg
+  return msg
 
 selectRoot :: IO (Maybe IP)
 selectRoot =

--- a/src/DNSC/Iterative.hs
+++ b/src/DNSC/Iterative.hs
@@ -196,7 +196,9 @@ selectAuthNS dom msg = runMaybeT $ do
 
       cacheVerifiedNS :: IP -> ResourceRecord -> ExceptT DNSError IO ()
       cacheVerifiedNS a aRR  = do
-        good <- verifyA aRR
+        good <- if skipVerify
+                then return True
+                else verifyA aRR
         if good
           then liftIO $ do cacheRR nsRR
                            cacheRR aRR
@@ -253,6 +255,14 @@ v6PtrDomain ipv6 = dom
     hxs = reverse $ concatMap w16hx $ fromIPv6 ipv6
     showH x = showHex x ""
     dom = intercalate "." $ map showH hxs ++ ["ip6.arpa."]
+
+{-
+逆引きによる verify をするべきか?
+
+たとえば e.in-addr-servers.arpa.  は正引きして逆引きすると  anysec.apnic.net. になって一致しない
+ -}
+skipVerify :: Bool
+skipVerify = True
 
 verifyA :: ResourceRecord -> DNSQuery Bool
 verifyA aRR@(ResourceRecord { rrname = ns }) =

--- a/src/DNSC/Iterative.hs
+++ b/src/DNSC/Iterative.hs
@@ -344,18 +344,3 @@ printResult = either print pmsg
       ["additional:"] ++
       map show (DNS.additional msg) ++
       [""]
-
------
-
-_examples :: IO ()
-_examples =
-  mapM_ ((printResult =<<) . uncurry runQuery)
-  [ ("google.com", DNS.NS)
-  , ("iij.ad.jp", DNS.NS)
-  , ("google.com", DNS.MX)
-  , ("iij.ad.jp", DNS.MX)
-  , ("www.google.com", DNS.A)
-  , ("www.iij.ad.jp", DNS.A)
-  , ("5.0.130.210.in-addr.arpa.", DNS.PTR) -- 210.130.0.5
-  , ("porttest.dns-oarc.net", DNS.TXT)
-  ]

--- a/src/DNSC/Iterative.hs
+++ b/src/DNSC/Iterative.hs
@@ -1,4 +1,15 @@
-module DNSC.Iterative where
+module DNSC.Iterative (
+  -- * query interfaces
+  runQuery,
+  runQuery1,
+  runIterative,
+  rootNS, AuthNS,
+  printResult,
+
+  -- * low-level interfaces
+  DNSQuery, runDNSQuery,
+  query, query1, iterative,
+  ) where
 
 import Control.Concurrent (forkIO)
 import Control.Monad (when, void)

--- a/src/DNSC/Iterative.hs
+++ b/src/DNSC/Iterative.hs
@@ -1,0 +1,226 @@
+module DNSC.Iterative where
+
+import Control.Monad (when)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Maybe (MaybeT (..))
+import Control.Monad.Trans.Except (ExceptT (..), runExceptT, throwE)
+-- import Data.Monoid (Last (..))
+import qualified Data.ByteString.Char8 as B8
+import Data.Maybe (mapMaybe, listToMaybe)
+import Data.List (isSuffixOf, unfoldr)
+
+import Data.IP (IP (IPv4, IPv6))
+import Network.DNS
+  (Domain, ResolvConf (..), FlagOp (FlagClear), DNSError, RData (..),
+   TYPE(A), ResourceRecord (ResourceRecord, rrname, rdata), DNSMessage)
+import qualified Network.DNS as DNS
+
+
+type Name = String
+
+validate :: Name -> Bool
+validate = not . null
+-- validate = all (not . null) . splitOn "."
+
+-- nomalize (domain) name to absolute name
+normalize :: Name -> Maybe Name
+normalize "." = Just "."
+normalize s
+  -- empty part is not valid, empty name is not valid
+  | validate rn   = Just nn
+  | otherwise     = Nothing  -- not valid
+  where
+    (rn, nn) | "." `isSuffixOf` s = (init s, s)
+             | otherwise          = (s, s ++ ".")
+
+-- get parent name for valid name
+parent :: String -> String
+parent n
+  | null dotp    =  error "parent: empty name is not valid."
+  | dotp == "."  =  "."  -- parent of "." is "."
+  | otherwise    =  tail dotp
+  where
+    dotp = dropWhile (/= '.') n
+
+-- get domain list for normalized name
+domains :: Name -> [Name]
+domains "."  = []
+domains name
+  | "." `isSuffixOf` name = name : unfoldr parent_ name
+  | otherwise             = error "domains: normalized name is required."
+  where
+    parent_ n
+      | p == "."   =  Nothing
+      | otherwise  =  Just (p, p)
+      where
+        p = parent n
+
+-----
+
+rootServers :: [IP]
+rootServers =
+  [ read "198.41.0.4"     -- a
+  , read "192.58.128.30"  -- j
+  , read "2001:503:ba3e::2:30"
+  ]
+
+-----
+
+{-
+type Error = Last DNSError
+
+dnsError :: DNSError -> Error
+dnsError = Last . Just
+
+mapDnsError :: Either DNSError a -> Either Error a
+mapDnsError = either (Left . dnsError) Right
+ -}
+
+type DNSQuery = ExceptT DNSError IO
+
+---
+
+{-
+反復検索の概要
+
+目的のドメインに対して、TLD(トップレベルドメイン) から子ドメインの方向へと順に、権威サーバへの A クエリを繰り返す.
+権威サーバへの A クエリの返答メッセージには、
+authority セクションに、次の権威サーバの名前 (NS) が、
+additional セクションにその名前に対するアドレス (A および AAAA) が入っている.
+この情報を使って、繰り返し、子ドメインへの検索を行なう.
+検索ドメインの初期値はTLD、権威サーバの初期値はルートサーバとなる.
+ -}
+
+withNormalized :: Name -> (Name -> DNSQuery a) -> IO (Either DNSError a)
+withNormalized n action = runExceptT $ do
+  action =<< maybe (throwE DNS.IllegalDomain) return (normalize n)
+
+runQuery :: Name -> TYPE -> IO (Either DNSError DNSMessage)
+runQuery n typ = withNormalized n (`query` typ)
+
+-- 反復検索を使ったクエリ. 結果が CNAME なら繰り返し解決する.
+query :: Name -> TYPE -> DNSQuery DNSMessage
+query n typ = do
+  msg <- query1 n typ
+  -- TODO: 目的の TYPE と CNAME が両方あったらエラーにする
+  let cname = listToMaybe $ mapMaybe takeCNAME $ DNS.answer msg
+  maybe (pure msg) (uncurry resolveCNAME) cname
+  where
+
+    takeCNAME (rr@ResourceRecord { rdata = RD_CNAME cn})
+      | rrname rr == B8.pack n  =  Just (cn, rr)
+    takeCNAME _                 =  Nothing
+
+    -- TODO: CNAME 解決の回数制限
+    resolveCNAME cn cnRR = do
+      x <- query (B8.unpack cn) typ
+      lift $ cacheRR cnRR
+      return x
+
+runQuery1 :: Name -> TYPE -> IO (Either DNSError DNSMessage)
+runQuery1 n typ = withNormalized n (`query1` typ)
+
+-- 反復検索を使ったクエリ. CNAME は解決しない.
+query1 :: Name -> TYPE -> DNSQuery DNSMessage
+query1 n typ = do
+  when debug $ liftIO $ putStrLn $ "query1: " ++ show (n, typ)
+  roota <- maybe (throwE DNS.BadConfiguration) pure =<< liftIO selectRoot
+  sa <- iterative roota n
+  ExceptT $ qNorec1 sa (B8.pack n) typ
+
+selectRoot :: IO (Maybe IP)
+selectRoot =
+  -- TODO: customize selection
+  -- naive implementation
+  return $ listToMaybe as
+  where
+    as = rootServers
+
+runIterative :: IP -> Name -> IO (Either DNSError IP)
+runIterative sa n = withNormalized n $ iterative sa
+
+-- 反復検索でドメインの NS のアドレスを得る
+iterative :: IP -> Name -> DNSQuery IP
+iterative sa n = iterative_ sa $ reverse $ domains n
+
+-- 反復検索の本体
+iterative_ :: IP -> [Name] -> DNSQuery IP
+iterative_ sa []     = return sa  -- 最後に返った NS
+iterative_ sa (x:xs) = do
+  when debug $ liftIO $ putStrLn $ "iterative: " ++ show (sa, name)
+  msg <- ExceptT $ qstep sa name
+  selectAuthNS name msg >>=
+    maybe
+    (iterative_ sa xs)    -- ex. or.jp, ad.jp, NS が返らない場合は同じ server address で子ドメインへ. 通常のホスト名もこのケース
+    (\nsa -> iterative_ nsa xs)
+  where
+    name = B8.pack x
+
+qstep :: IP -> Domain -> IO (Either DNSError DNSMessage)
+qstep aserver name = qNorec1 aserver name A
+
+qNorec1 :: IP -> Domain -> TYPE -> IO (Either DNSError DNSMessage)
+qNorec1 aserver name typ = do
+  rs <- DNS.makeResolvSeed conf
+  DNS.withResolver rs $ \resolver -> DNS.lookupRaw resolver name typ
+  where
+    conf = DNS.defaultResolvConf
+           { resolvInfo = DNS.RCHostName $ show aserver
+           , resolvTimeout = 5 * 1000 * 1000
+           , resolvRetry = 2
+           , resolvQueryControls = DNS.rdFlag FlagClear
+           }
+
+selectAuthNS :: Domain -> DNSMessage -> DNSQuery (Maybe IP)
+selectAuthNS dom msg = runMaybeT $ do
+  (ns, nsRR) <- MaybeT $ liftIO $ selectNS $ mapMaybe takeNS $ DNS.authority msg
+  (a , aRR)  <- MaybeT $ liftIO $ selectA $ mapMaybe (takeAx ns) $ DNS.additional msg
+
+  when debug $ liftIO $ putStrLn $ "selectAuthNS: " ++ show (dom, (ns, a))
+
+  lift $ do
+    good <- verifyA aRR
+    if good
+      then liftIO $ do cacheRR nsRR
+                       cacheRR aRR
+      else do liftIO $ putStrLn $ "selectAuthNS: verification failed: " ++ show (ns, a)
+              throwE DNS.IllegalDomain
+
+  return a
+
+  where
+
+    takeNS (rr@ResourceRecord { rdata = RD_NS ns})
+      | rrname rr == dom  =  Just (ns, rr)
+    takeNS _              =  Nothing
+
+    takeAx ns (rr@ResourceRecord { rdata = RD_A ipv4 })
+      | rrname rr == ns  =  Just (IPv4 ipv4, rr)
+    takeAx ns (rr@ResourceRecord { rdata = RD_AAAA ipv6 })
+      | rrname rr == ns  =  Just (IPv6 ipv6, rr)
+    takeAx _  _          =  Nothing
+
+selectNS :: [a] -> IO (Maybe a)
+selectNS rs =
+  -- TODO: customize selection
+  -- naive implementation
+  return $ listToMaybe rs
+
+selectA :: [a] -> IO (Maybe a)
+selectA as = do
+  when (null as) $ putStrLn $ "selectA: warning: zero address list is passed."
+  -- TODO: customize selection
+  -- naive implementation
+  return $ listToMaybe as
+
+verifyA :: ResourceRecord -> DNSQuery Bool
+verifyA _ = return True
+-- TODO: reverse lookup to verify
+
+cacheRR :: ResourceRecord -> IO ()
+cacheRR rr = do
+  when debug $ putStrLn $ "cacheRR: " ++ show rr
+
+debug :: Bool
+debug = True

--- a/src/DNSC/Iterative.hs
+++ b/src/DNSC/Iterative.hs
@@ -126,7 +126,7 @@ query n typ = do
 
   -- TODO: CNAME 解決の回数制限
   let resolveCNAME cn cnRR = do
-        when (any ((== typ) . rrtype) answers) $ throwE DNS.UnexpectedRDATA
+        when (any ((== typ) . rrtype) answers) $ throwE DNS.UnexpectedRDATA  -- CNAME と目的の TYPE が同時に存在した場合はエラー
         x <- query (B8.unpack cn) typ
         lift $ cacheRR cnRR
         return x

--- a/src/DNSC/Iterative.hs
+++ b/src/DNSC/Iterative.hs
@@ -238,3 +238,33 @@ cacheRR rr = do
 
 debug :: Bool
 debug = True
+
+printResult :: Either DNSError DNSMessage -> IO ()
+printResult = either print pmsg
+  where
+    pmsg msg =
+      putStr $ unlines $
+      ["answer:"] ++
+      map show (DNS.answer msg) ++
+      [""] ++
+      ["authority:"] ++
+      map show (DNS.authority msg) ++
+      [""] ++
+      ["additional:"] ++
+      map show (DNS.additional msg) ++
+      [""]
+
+-----
+
+_examples :: IO ()
+_examples =
+  mapM_ ((printResult =<<) . uncurry runQuery)
+  [ ("google.com", DNS.NS)
+  , ("iij.ad.jp", DNS.NS)
+  , ("google.com", DNS.MX)
+  , ("iij.ad.jp", DNS.MX)
+  , ("www.google.com", DNS.A)
+  , ("www.iij.ad.jp", DNS.A)
+  , ("5.0.130.210.in-addr.arpa.", DNS.PTR) -- 210.130.0.5
+  , ("porttest.dns-oarc.net", DNS.TXT)
+  ]

--- a/src/DNSC/RootServers.hs
+++ b/src/DNSC/RootServers.hs
@@ -1,0 +1,58 @@
+module DNSC.RootServers (
+  rootServers
+  ) where
+
+import qualified Data.ByteString.Char8 as B8
+
+import Network.DNS
+  (RData (..), TYPE(NS, A, AAAA), ResourceRecord (ResourceRecord, rrname, rrtype, rdata))
+import qualified Network.DNS as DNS
+
+rootServers :: ([ResourceRecord], [ResourceRecord])
+rootServers =
+  (
+    [ mkRR "." NS 252280 (RD_NS (B8.pack "a.root-servers.net."))
+    , mkRR "." NS 252280 (RD_NS (B8.pack "b.root-servers.net."))
+    , mkRR "." NS 252280 (RD_NS (B8.pack "c.root-servers.net."))
+    , mkRR "." NS 252280 (RD_NS (B8.pack "d.root-servers.net."))
+    , mkRR "." NS 252280 (RD_NS (B8.pack "e.root-servers.net."))
+    , mkRR "." NS 252280 (RD_NS (B8.pack "f.root-servers.net."))
+    , mkRR "." NS 252280 (RD_NS (B8.pack "g.root-servers.net."))
+    , mkRR "." NS 252280 (RD_NS (B8.pack "h.root-servers.net."))
+    , mkRR "." NS 252280 (RD_NS (B8.pack "i.root-servers.net."))
+    , mkRR "." NS 252280 (RD_NS (B8.pack "j.root-servers.net."))
+    , mkRR "." NS 252280 (RD_NS (B8.pack "k.root-servers.net."))
+    , mkRR "." NS 252280 (RD_NS (B8.pack "l.root-servers.net."))
+    , mkRR "." NS 252280 (RD_NS (B8.pack "m.root-servers.net."))
+    ]
+  ,
+    [ mkRR "a.root-servers.net." A 21566 (RD_A (read "198.41.0.4"))
+    , mkRR "a.root-servers.net." AAAA 60281 (RD_AAAA (read "2001:503:ba3e::2:30"))
+    , mkRR "b.root-servers.net." A 252280 (RD_A (read "199.9.14.201"))
+    , mkRR "b.root-servers.net." AAAA 252280 (RD_AAAA (read "2001:500:200::b"))
+    , mkRR "c.root-servers.net." A 252280 (RD_A (read "192.33.4.12"))
+    , mkRR "c.root-servers.net." AAAA 252280 (RD_AAAA (read "2001:500:2::c"))
+    , mkRR "d.root-servers.net." A 252280 (RD_A (read "199.7.91.13"))
+    , mkRR "d.root-servers.net." AAAA 252280 (RD_AAAA (read "2001:500:2d::d"))
+    , mkRR "e.root-servers.net." A 252280 (RD_A (read "192.203.230.10"))
+    , mkRR "e.root-servers.net." AAAA 252280 (RD_AAAA (read "2001:500:a8::e"))
+    , mkRR "f.root-servers.net." A 252280 (RD_A (read "192.5.5.241"))
+    , mkRR "f.root-servers.net." AAAA 252280 (RD_AAAA (read "2001:500:2f::f"))
+    , mkRR "g.root-servers.net." A 252280 (RD_A (read "192.112.36.4"))
+    , mkRR "g.root-servers.net." AAAA 252280 (RD_AAAA (read "2001:500:12::d0d"))
+    , mkRR "h.root-servers.net." A 252280 (RD_A (read "198.97.190.53"))
+    , mkRR "h.root-servers.net." AAAA 252280 (RD_AAAA (read "2001:500:1::53"))
+    , mkRR "i.root-servers.net." A 252280 (RD_A (read "192.36.148.17"))
+    , mkRR "i.root-servers.net." AAAA 252280 (RD_AAAA (read "2001:7fe::53"))
+    , mkRR "j.root-servers.net." A 310698 (RD_A (read "192.58.128.30"))
+    , mkRR "j.root-servers.net." AAAA 252280 (RD_AAAA (read "2001:503:c27::2:30"))
+    , mkRR "k.root-servers.net." A 252280 (RD_A (read "193.0.14.129"))
+    , mkRR "k.root-servers.net." AAAA 252280 (RD_AAAA (read "2001:7fd::1"))
+    , mkRR "l.root-servers.net." A 252280 (RD_A (read "199.7.83.42"))
+    , mkRR "l.root-servers.net." AAAA 252280 (RD_AAAA (read "2001:500:9f::42"))
+    , mkRR "m.root-servers.net." A 252280 (RD_A (read "202.12.27.33"))
+    , mkRR "m.root-servers.net." AAAA 252280 (RD_AAAA (read "2001:dc3::35"))
+    ]
+  )
+  where
+    mkRR n ty tt rd = ResourceRecord { rrname = B8.pack n, rrtype = ty, DNS.rrclass = DNS.classIN, DNS.rrttl = tt, rdata = rd }


### PR DESCRIPTION
Prototype implementation of iterative lookup.

- [x] simple iterative lookup
- [x] resolve CNAME in lookup result
- [x] resolve PTR. process for no glue records case
- [x] NS address reverse lookoup to verify
- [x] balancing multiple NS to send queries.