### PR TITLE
cache structure for RRSet with ranking

### DIFF
--- a/dns-resolver.cabal
+++ b/dns-resolver.cabal
@@ -20,6 +20,7 @@ extra-source-files:  CHANGELOG.md
 library
   exposed-modules:
                        DNSC.Iterative
+                       DNSC.Cache
 
   other-modules:
                        DNSC.RootServers
@@ -27,11 +28,27 @@ library
   build-depends:
                        base >=4 && <5
                      , bytestring
+                     , containers
                      , transformers
+                     , time
                      , random
                      , iproute
                      , dns
+                     , PSQueue
   hs-source-dirs:      src
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+
+Test-Suite cache-test
+  type:                exitcode-stdio-1.0
+  other-modules:       CacheProp
+  main-is:             cache.hs
+  build-depends:       base
+                     , bytestring
+                     , dns
+                     , dns-resolver
+                     , QuickCheck
+  hs-source-dirs:      test
   default-language:    Haskell2010
   ghc-options:         -Wall
 

--- a/src/DNSC/Cache.hs
+++ b/src/DNSC/Cache.hs
@@ -1,0 +1,328 @@
+{-# LANGUAGE StrictData #-}
+
+module DNSC.Cache (
+  -- * cache interfaces
+  empty,
+  lookup,
+  takeRRSet,
+  insert,
+  expires,
+  size,
+  Timestamp,
+
+  Ranking, rankAuthAnswer, rankAnswer, rankAdditional,
+  rankedAnswer, rankedAuthority, rankedAdditional,
+
+  insertSetFromSection,
+
+  -- * handy interface
+  insertRRs,
+
+  -- * low-level interfaces
+  Cache (Cache), Key (..), Val (..), CRSet (..),
+  extractRRSet,
+  queueSize, (<+), alive,
+  expire1, member,
+  dump, consistent,
+  dumpKeys, minKey,
+  ) where
+
+import Prelude hiding (lookup)
+import Control.Monad (guard)
+import Data.Ord (Down (..))
+import Data.Function (on)
+import Data.Maybe (isJust, catMaybes)
+import Data.Either (partitionEithers)
+import Data.List (group, groupBy, sortOn, uncons)
+import Data.Word (Word16, Word32)
+import Data.ByteString.Short (ShortByteString, toShort, fromShort)
+import Data.Time (UTCTime, addUTCTime, diffUTCTime)
+import Data.Map (Map)
+import qualified Data.Map.Strict as Map
+
+import Data.PSQueue (Binding ((:->)), PSQ)
+import qualified Data.PSQueue as PSQ
+import Data.IP (IPv4, IPv6)
+import Network.DNS
+  (Domain, CLASS, TTL, TYPE (..), RData (..),
+   ResourceRecord (ResourceRecord), DNSMessage)
+import qualified Network.DNS as DNS
+
+
+---
+
+type CDomain = ShortByteString
+type CMailbox = ShortByteString
+type CTxt = ShortByteString
+
+data CRSet
+  = CR_A [IPv4]
+  | CR_NS [CDomain]
+  | CR_CNAME CDomain
+  | CR_SOA CDomain CMailbox
+    Word32 Word32 Word32 Word32 Word32
+  | CR_PTR [CDomain]
+  | CR_MX [(Word16, CDomain)]
+  | CR_TXT [CTxt]
+  | CR_AAAA [IPv6]
+  deriving (Eq, Ord, Show)
+
+---
+
+-- Ranking data (section 5.4.1 of RFC2181 - Clarifications to the DNS Specification)
+-- <https://datatracker.ietf.org/doc/html/rfc2181#section-5.4.1>
+
+data Ranking_
+{- + Data from a primary zone file, other than glue data, -}
+  --
+{- + Data from a zone transfer, other than glue, -}
+  --
+{- + The authoritative data included in the answer section of an
+     authoritative reply. -}
+  = RankAuthAnswer
+{- + Data from the authority section of an authoritative answer, -}
+  -- -- avoiding issue of authority section in reply with aa flag
+{- + Glue from a primary zone, or glue from a zone transfer, -}
+  --
+{- + Data from the answer section of a non-authoritative answer, and
+     non-authoritative data from the answer section of authoritative
+     answers, -}
+  | RankAnswer
+{- + Additional information from an authoritative answer,
+     Data from the authority section of a non-authoritative answer,
+     Additional information from non-authoritative answers. -}
+  | RankAdditional
+  deriving (Eq, Ord, Show)
+
+type Ranking = Down Ranking_  -- upper rank is better
+
+rankAuthAnswer, rankAnswer, rankAdditional :: Ranking
+rankAuthAnswer  =  Down RankAuthAnswer
+rankAnswer      =  Down RankAnswer
+rankAdditional  =  Down RankAdditional
+
+rankedSection :: Maybe Ranking -> Maybe Ranking -> (DNSMessage -> [ResourceRecord])
+              -> DNSMessage -> Maybe ([ResourceRecord], Ranking)
+rankedSection authRank noauthRank section msg =
+  (,) (section msg)
+  <$> if DNS.authAnswer flags then authRank else noauthRank
+  where
+    flags = DNS.flags $ DNS.header msg
+
+rankedAnswer :: DNSMessage -> Maybe ([ResourceRecord], Ranking)
+rankedAnswer =
+  rankedSection
+  (Just rankAuthAnswer)
+  (Just rankAnswer)
+  DNS.answer
+
+rankedAuthority :: DNSMessage -> Maybe ([ResourceRecord], Ranking)
+rankedAuthority =
+  rankedSection
+  Nothing  -- avoid security hole with authorized reply and authority section case
+  (Just rankAdditional)
+  DNS.authority
+
+rankedAdditional :: DNSMessage -> Maybe ([ResourceRecord], Ranking)
+rankedAdditional =
+  rankedSection
+  (Just rankAdditional)
+  (Just rankAdditional)
+  DNS.additional
+
+---
+
+data Key = Key CDomain TYPE CLASS deriving (Eq, Ord, Show)
+data Val = Val CRSet Ranking deriving Show
+
+type Timestamp = UTCTime
+
+data Cache = Cache (PSQ Key Timestamp) (Map Key Val) deriving Show
+
+empty :: Cache
+empty = Cache PSQ.empty Map.empty
+
+lookup :: Timestamp
+       -> Domain -> TYPE -> CLASS
+       -> Cache -> Maybe ([ResourceRecord], Ranking)
+lookup now dom = lookup_ now result (fromDomain dom)
+  where
+    result k ttl (Val crs rank) = (extractRRSet k ttl crs, rank)
+
+lookup_ :: Timestamp -> (Key -> TTL -> Val -> a)
+        -> CDomain -> TYPE -> CLASS
+        -> Cache -> Maybe a
+lookup_ now mk dom typ cls (Cache lifetimes crss) = do
+  let k = Key dom typ cls
+  eol <- k `PSQ.lookup` lifetimes
+  ttl <- alive now eol
+  rds <- k `Map.lookup` crss
+  return $ mk k ttl rds
+
+insertRRs :: Timestamp -> [ResourceRecord] -> Ranking -> Cache -> Maybe Cache
+insertRRs now rrs rank c = insertRRSet =<< takeRRSet rrs
+  where
+    insertRRSet rrset = uncurry (uncurry $ insert now) rrset rank c
+
+{- |
+  Insert RR-list example with error-handling
+
+@
+   case takeRRSet rrList of  -- take RRSet with error-handling
+     Nothing  ->  ...        -- inconsistent RR-list error
+     Just rrset  ->
+       maybe
+       ( ... )   -- no update
+       ( ... )   -- update with new-cache
+       $ uncurry (uncurry $ insert now) rrset ranking cache
+@
+ -}
+insert :: Timestamp -> Key -> TTL -> CRSet -> Ranking -> Cache -> Maybe Cache
+insert now k@(Key dom typ cls) ttl crs rank c@(Cache lifetimes vals) =
+  maybe inserted withOldRank lookupRank
+  where
+    lookupRank =
+      lookup_ now (\_ _ (Val _ r) -> r)
+      dom typ cls c
+    withOldRank r = do
+      guard $ rank > r
+      inserted
+    eol = now <+ ttl
+    inserted =
+      return $
+      Cache
+      (PSQ.insert k eol lifetimes)
+      (Map.insert k (Val crs rank) vals)
+
+expires :: Timestamp -> Cache -> Maybe Cache
+expires now = rec0
+  where
+    rec0 c = rec1 <$> expire1 now c
+    rec1 c = maybe c rec1 $ expire1 now c
+
+expire1 :: Timestamp -> Cache -> Maybe Cache
+expire1 now (Cache lifetimes crss) =
+  uncurry ex =<< PSQ.minView lifetimes
+  where
+    ex (k :-> eol) lifetimes'
+      | Just {} <- alive now eol  =  Nothing
+      | otherwise                 =  Just $ Cache lifetimes' $ Map.delete k crss
+
+alive :: Timestamp -> Timestamp -> Maybe TTL
+alive now eol = do
+  let ttl' = eol `diffUTCTime` now
+  guard $ ttl' >= 1  -- TTL が Word32 なので、負のときに floor すると underflow してしまう
+  return $ floor ttl'
+
+size :: Cache -> Int
+size (Cache _ crss) = Map.size crss
+
+---
+{- debug interfaces -}
+
+queueSize :: Cache -> Int
+queueSize (Cache lifetimes _) = PSQ.size lifetimes
+
+member :: Timestamp
+       -> CDomain -> TYPE -> CLASS
+       -> Cache -> Bool
+member now dom typ cls = isJust . lookup_ now (\_ _ _ -> ()) dom typ cls
+
+dump :: Cache -> [(Key, (Timestamp, Val))]
+dump (Cache lifetimes vals) =
+  catMaybes $ zipWith op (PSQ.toAscList lifetimes) (Map.toAscList vals)
+  where
+    op (lk :-> eol) (k, v)
+      | lk == k    =  Just (k, (eol, v))
+      | otherwise  =  Nothing
+
+consistent :: Cache -> Bool
+consistent cache = queueSize cache == sz && length (dump cache) == sz
+  where sz = size cache
+
+dumpKeys :: Cache -> [(Key, Timestamp)]
+dumpKeys (Cache lifetimes _) = map unBinding $ PSQ.toAscList lifetimes
+  where
+    unBinding (k :-> eol) = (k, eol)
+
+minKey :: Cache -> Maybe (Key, Timestamp)
+minKey = fmap fst . uncons . dumpKeys
+
+---
+
+(<+) :: Timestamp -> TTL -> Timestamp
+now <+ ttl = fromIntegral ttl `addUTCTime` now
+
+infixl 6 <+
+
+toDomain :: CDomain -> DNS.Domain
+toDomain = fromShort
+
+fromDomain :: DNS.Domain -> CDomain
+fromDomain = toShort
+
+toRDatas :: CRSet -> [RData]
+toRDatas crs = case crs of
+  CR_A as     ->  map RD_A as
+  CR_NS ds    ->  map (RD_NS . toDomain) ds
+  CR_CNAME d  -> [RD_CNAME $ toDomain d]
+  CR_SOA dom m a b c d e -> [RD_SOA (toDomain dom) (fromShort m) a b c d e]
+  CR_PTR ds   ->  map (RD_PTR . toDomain) ds
+  CR_MX ps    ->  map (\(w, d) -> RD_MX w $ toDomain d) ps
+  CR_TXT ts   ->  map (RD_TXT . fromShort) ts
+  CR_AAAA as  ->  map RD_AAAA as
+
+fromRDatas :: [RData] -> Maybe CRSet
+fromRDatas []    = Nothing
+fromRDatas rds@(x:xs) = case x of
+  RD_A {}     ->  Just $ CR_A [ a | RD_A a <- rds ]
+  RD_NS {}    ->  Just $ CR_NS [ fromDomain d | RD_NS d <- rds ]
+  RD_CNAME d
+    | null xs   ->  Just $ CR_CNAME (fromDomain d)
+    | otherwise ->  Nothing
+  RD_SOA dom m a b c d e
+    | null xs   ->  Just $ CR_SOA (fromDomain dom) (toShort m) a b c d e
+    | otherwise ->  Nothing
+  RD_PTR {}   ->  Just $ CR_PTR [ fromDomain d | RD_PTR d <- rds ]
+  RD_MX {}    ->  Just $ CR_MX [ (w, fromDomain d) | RD_MX w d <- rds ]
+  RD_TXT {}   ->  Just $ CR_TXT [ toShort t | RD_TXT t <- rds ]
+  RD_AAAA {}  ->  Just $ CR_AAAA [ a | RD_AAAA a <- rds ]
+  _           ->  Nothing
+
+rdTYPE :: RData -> Maybe TYPE
+rdTYPE cr = case cr of
+  RD_A {}      ->  Just A
+  RD_NS {}     ->  Just NS
+  RD_CNAME {}  ->  Just CNAME
+  RD_SOA {}    ->  Just SOA
+  RD_PTR {}    ->  Just PTR
+  RD_MX {}     ->  Just MX
+  RD_TXT {}    ->  Just TXT
+  RD_AAAA {}   ->  Just AAAA
+  _            ->  Nothing
+
+rrSetKey :: ResourceRecord -> Maybe (Key, TTL)
+rrSetKey (ResourceRecord rrname rrtype rrclass rrttl rd)
+  | rrclass == DNS.classIN &&
+    rdTYPE rd == Just rrtype  =  Just (Key (fromDomain rrname) rrtype rrclass, rrttl)
+  | otherwise                 =  Nothing
+
+takeRRSet :: [ResourceRecord] -> Maybe ((Key, TTL), CRSet)
+takeRRSet []        =    Nothing
+takeRRSet rrs@(_:_) = do
+  ps <- mapM rrSetKey rrs         -- それぞれ RR で、rrtype と rdata が整合している
+  guard $ length (group ps) == 1  -- query のキーと TTL がすべて一致
+  (k', _) <- uncons ps            -- rrs が空でないので必ず成功するはず
+  rds <- fromRDatas $ map DNS.rdata rrs
+  return (k', rds)
+
+extractRRSet :: Key -> TTL -> CRSet -> [ResourceRecord]
+extractRRSet (Key dom ty cls) ttl = map (ResourceRecord (toDomain dom) ty cls ttl) . toRDatas
+
+insertSetFromSection :: [ResourceRecord] -> Ranking -> ([[ResourceRecord]], [(((Key, TTL), CRSet), Ranking)])
+insertSetFromSection rs0 r0 = (errRS, iset rrss r0)
+  where
+    key rr = (DNS.rrname rr, DNS.rrtype rr, DNS.rrclass rr)
+    getRRSet rs = maybe (Left rs) Right $ takeRRSet rs
+    (errRS, rrss) = partitionEithers . map getRRSet . groupBy ((==) `on` key) . sortOn key $ rs0
+    iset ss rank = [ (rrset, rank) | rrset <- ss]

--- a/test/CacheProp.hs
+++ b/test/CacheProp.hs
@@ -1,0 +1,427 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+module CacheProp
+  ( props
+  , run
+  ) where
+
+import Test.QuickCheck
+
+import Data.Maybe (mapMaybe)
+import Data.List (sort)
+import Data.Char (ord)
+import Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Short as Short
+import Network.DNS (TYPE (..), TTL)
+import qualified Network.DNS as DNS
+import Text.Read (readMaybe)
+
+import DNSC.Cache
+  (Cache (..), Key (Key), Val (Val), CRSet (..), Timestamp, (<+),
+   Ranking, rankAuthAnswer, rankAnswer, rankAdditional,
+   takeRRSet, extractRRSet)
+import qualified DNSC.Cache as Cache
+
+
+{-# ANN module "HLint: ignore Use fromMaybe" #-}
+
+-----
+
+packS8 :: String -> ShortByteString
+packS8 = Short.pack . map (fromIntegral . ord)
+
+toDomain :: ShortByteString -> DNS.Domain
+toDomain = Short.fromShort
+
+_crsTYPE :: CRSet -> DNS.TYPE
+_crsTYPE cr = case cr of
+  CR_A     {}  ->  DNS.A
+  CR_NS    {}  ->  DNS.NS
+  CR_CNAME {}  ->  DNS.CNAME
+  CR_SOA   {}  ->  DNS.SOA
+  CR_PTR   {}  ->  DNS.PTR
+  CR_MX    {}  ->  DNS.MX
+  CR_TXT   {}  ->  DNS.TXT
+  CR_AAAA  {}  ->  DNS.AAAA
+
+-----
+
+domainList :: [ShortByteString]
+domainList =
+  map packS8
+  [ "example.com."
+  , "example.ne.jp."
+  , "example.net.uk."
+  ]
+
+nameList :: [ShortByteString]
+nameList =
+  map packS8
+  [ "www.example.com."
+  , "mail.example.com."
+  , "example.ne.jp."
+  ]
+
+v4List :: Read a => [a]
+v4List = map read [ "192.168.10.1", "192.168.10.2", "192.168.10.3", "192.168.10.4" ]
+
+v6List :: Read a => [a]
+v6List = map read [ "fe80::000a:0001", "fe80::000a:0002", "fe80::000a:0003", "fe80::000a:0004" ]
+
+nsList :: [ShortByteString]
+nsList =
+  map packS8
+  [ "ns1.example.com.", "ns2.example.com.", "ns3.example.com."
+  , "ns4.example.com.", "ns5.example.com." ]
+
+ts0 :: Timestamp
+ts0 =
+  maybe (error "cache-test: Timestamp: wrong setup") id
+  $ readMaybe "2022-01-01 00:00:00 UTC"
+
+-----
+
+data Update
+  = I Key TTL Val
+  | E
+  deriving Show
+
+runUpdate :: Timestamp -> Update -> Cache -> Cache
+runUpdate t u = case u of
+  I k ttl (Val crs rank) -> may $ Cache.insert t k ttl crs rank
+  E                      -> may $ Cache.expires t
+  where may f c = maybe c id $ f c
+
+foldUpdates :: [(Timestamp, Update)] -> Cache -> Cache
+foldUpdates = foldr (\p k -> k . uncurry runUpdate p) id
+
+removeKeyUpdates :: Key -> [(Timestamp, Update)] -> [(Timestamp, Update)]
+removeKeyUpdates k = filter (not . match)
+  where
+    match (_, I ik _ _)  =  k == ik
+    match (_, E)         =  False
+
+removeExpiresUpdates :: [(Timestamp, Update)] -> [(Timestamp, Update)]
+removeExpiresUpdates = filter (not . expire)
+  where
+    expire (_, E)  =  True
+    expire _       =  False
+
+rankings :: [Ranking]
+rankings = [rankAuthAnswer, rankAnswer, rankAdditional]
+
+-----
+
+genCrsAssoc :: [(TYPE, Gen CRSet)]
+genCrsAssoc =
+  [ (A, CR_A <$> listOf1 (elements v4List))
+  , (NS, CR_NS <$> listOf1 (elements nsList))
+  , (AAAA, CR_AAAA <$> listOf1 (elements v6List))
+  ]
+
+genWrongCRPair :: Gen (Key, CRSet)
+genWrongCRPair = do
+  (typ, genCrs) <- elements wrongs
+  key <- Key <$> elements domainList <*> pure typ <*> pure DNS.classIN
+  crs <- genCrs
+  pure (key, crs)
+  where
+    wrongs =
+      [ (typ, genCrs)
+      | typ <- [A, NS, AAAA]
+      , (gtyp, genCrs) <- genCrsAssoc
+      , typ /= gtyp
+      ]
+
+genCRsPair :: Gen (Key, Gen CRSet)
+genCRsPair = do
+  (typ, genCrs) <- elements genCrsAssoc
+  let labelList
+        | typ `elem` [NS, SOA, MX]  =  domainList
+        | otherwise                 =  nameList
+  (,)
+    <$> (Key <$> elements labelList <*> pure typ <*> pure DNS.classIN)
+    <*> pure genCrs
+
+genCRPair :: Gen (Key, CRSet)
+genCRPair = do
+  (key, genCrs) <- genCRsPair
+  crs <- genCrs
+  pure (key, crs)
+
+genTTL :: Gen TTL
+genTTL = choose (1, 7200000)
+
+genRanking :: Gen Ranking
+genRanking = elements rankings
+
+genTimestamp :: Gen Timestamp
+genTimestamp = (ts0 <+) <$> choose (1, 21600000)
+
+genUpdate :: Gen Update
+genUpdate =
+  frequency
+  [ (32, genInsert)
+  , (1, pure E)
+  ]
+  where
+    genInsert = do
+      (k, crs) <- genCRPair
+      I k <$> genTTL <*> (Val crs <$> genRanking)
+
+genUpdates :: Gen [(Timestamp, Update)]
+genUpdates = do
+  ks <- listOf genUpdate
+  tss <- sort <$> vectorOf (length ks) genTimestamp
+  pure $ zip tss ks
+
+genRankOrds :: Gen (Ranking, Ranking)
+genRankOrds = elements ords
+  where
+    ords =   [ (r1, r2) | r1 <- rankings, r2 <- rankings, r1 > r2 ]
+    -- ordered pairs
+
+genRankOrdsCo :: Gen (Ranking, Ranking)
+genRankOrdsCo = elements ordsCo
+  where
+    ordsCo = [ (r1, r2) | r1 <- rankings, r2 <- rankings, r1 <= r2 ]
+    -- complement pairs
+
+-----
+
+newtype AKey = AKey Key deriving Show
+
+instance Arbitrary AKey where
+  arbitrary = AKey <$> (Key <$> elements domainList <*> elements [A, NS, AAAA] <*> pure DNS.classIN)
+
+newtype AWrongCRPair = AWrongCRPair (Key, CRSet) deriving Show
+
+instance Arbitrary AWrongCRPair where
+  arbitrary = AWrongCRPair <$> genWrongCRPair
+
+newtype ATTL = ATTL TTL deriving Show
+
+instance Arbitrary ATTL where
+  arbitrary = ATTL <$> genTTL
+
+newtype ACRPair = ACRPair (Key, CRSet) deriving Show
+
+instance Arbitrary ACRPair where
+  arbitrary = ACRPair <$> genCRPair
+
+newtype ARanking = ARanking Ranking deriving Show
+
+instance Arbitrary ARanking where
+  arbitrary = ARanking <$> genRanking
+
+newtype ATimestamp = ATimestamp Timestamp deriving Show
+
+instance Arbitrary ATimestamp where
+  arbitrary = ATimestamp <$> genTimestamp
+
+newtype AUpdates = AUpdates [(Timestamp, Update)] deriving Show
+
+instance Arbitrary AUpdates where
+  arbitrary = AUpdates <$> genUpdates
+
+newtype ARankOrds = ARankOrds (Ranking, Ranking) deriving Show
+
+instance Arbitrary ARankOrds where
+  arbitrary = ARankOrds <$> genRankOrds
+
+newtype ARankOrdsCo = ARankOrdsCo (Ranking, Ranking) deriving Show
+
+instance Arbitrary ARankOrdsCo where
+  arbitrary = ARankOrdsCo <$> genRankOrdsCo
+
+newtype ACR2 = ACR2 (Key, (CRSet, CRSet)) deriving Show
+
+instance Arbitrary ACR2 where
+  arbitrary = ACR2 <$> gen
+    where
+      gen = do
+        (k, genCrs) <- genCRsPair
+        (,) k <$> ((,) <$> genCrs <*> genCrs)
+
+-----
+
+-- RRSet refine
+
+-- forall ((k, crs) :: AWrongCRPair) ttl . takeRRSet (extractRRSet k ttl crs) == Nothing
+rrsetTakeNothing :: AWrongCRPair -> ATTL -> Property
+rrsetTakeNothing (AWrongCRPair (k, crs)) (ATTL ttl) = takeRRSet (extractRRSet k ttl crs) === Nothing
+
+-- forall ((k, crs) :: ACRPair) ttl . takeRRSet (extractRRSet k ttl crs) == Just ((k, ttl), crs)
+rrsetExtractTake :: ACRPair -> ATTL  -> Property
+rrsetExtractTake (ACRPair (k, crs)) (ATTL ttl) = takeRRSet (extractRRSet k ttl crs) === Just ((k, ttl), crs)
+
+---
+
+-- cache size
+
+-- Cache.size Cache.empty == 0
+sizeEmpty :: Property
+sizeEmpty = once $ Cache.size Cache.empty === 0
+
+-- forall cache . sizeConsistent cache
+sizeConsistent :: AUpdates -> Property
+sizeConsistent (AUpdates us) =
+  Cache.consistent cache .&&. Cache.queueSize cache === sz .&&. length (Cache.dump cache) === sz
+  where cache = foldUpdates us Cache.empty
+        sz = Cache.size cache
+
+-- size of cache after new key is inserted
+sizeNewInserted :: ACRPair -> ATTL -> ARanking -> AUpdates -> Property
+sizeNewInserted (ACRPair (k, crs)) (ATTL ttl_) (ARanking rank) (AUpdates us) =
+  maybe (property False) checkSize
+  $ Cache.insert ts0 k ttl_ crs rank rcache
+  where
+    checkSize ins = Cache.size ins === Cache.size rcache + 1
+    rcache = foldUpdates (removeKeyUpdates k us) Cache.empty  -- 挿入する Key を除去
+
+-- forall ((k, crs) :: ACRPair) ttl cache rs . (rs == extractRRSet k ttl crs) ->
+-- (       member k cache  -> size inserted == size cache   \/
+--    not (member k cache) -> size inserted == size cache + 1 )
+sizeInserted :: ACRPair -> ATTL -> ARanking -> AUpdates -> Property
+sizeInserted (ACRPair (k@(Key dom typ cls), crs)) (ATTL ttl_) (ARanking rank) (AUpdates us) =
+  maybe (property Discard) checkSize
+  $ Cache.insert ts0 k ttl_ crs rank cache
+  where
+    checkSize ins
+      | Cache.member ts0 dom typ cls cache  =  Cache.size ins === Cache.size cache
+      | otherwise                           =  Cache.size ins === Cache.size cache + 1
+    cache = foldUpdates us Cache.empty
+
+sizeExpire1MinKey :: AUpdates -> Property
+sizeExpire1MinKey (AUpdates us) =
+  maybe (property Discard) checkSize $ Cache.minKey cache
+  where
+    cache = foldUpdates us Cache.empty
+    checkSize (_, minTS) =
+      ( (+ 1) . Cache.size <$> Cache.expire1 minTS cache ) === Just (Cache.size cache)
+
+---
+
+-- lookup
+
+lookupEmpty :: AKey -> Property
+lookupEmpty (AKey (Key dom typ cls)) = Cache.lookup ts0 (toDomain dom) typ cls Cache.empty === Nothing
+
+-- lookup key cache after inserted as new key
+lookupNewInserted :: ACRPair -> ATTL -> ARanking -> AUpdates -> Property
+lookupNewInserted (ACRPair (k@(Key dom typ cls), crs)) (ATTL ttl_) (ARanking rank) (AUpdates us)  =
+  (Cache.lookup ts0 (toDomain dom) typ cls =<< Cache.insert ts0 k ttl_ crs rank rcache)
+  =/=
+  Nothing
+  where
+    rcache = foldUpdates (removeKeyUpdates k us) Cache.empty  -- 挿入する Key を除去
+
+lookupInserted :: ACRPair -> ATTL -> ARanking -> AUpdates -> Property
+lookupInserted (ACRPair (k@(Key dom typ cls), crs)) (ATTL ttl_) (ARanking rank) (AUpdates us)  =
+  case Cache.insert ts0 k ttl_ crs rank cache of
+    Nothing   ->  label "old" $ Cache.lookup ts0 (toDomain dom) typ cls cache =/= Nothing
+    Just ins  ->  label "new" $ Cache.lookup ts0 (toDomain dom) typ cls ins   =/= Nothing
+  where
+    cache = foldUpdates us Cache.empty
+
+lookupTTL :: ACRPair -> ATTL -> ARanking -> ATimestamp -> AUpdates -> Property
+lookupTTL (ACRPair (k@(Key dom typ cls), crs)) (ATTL ttl_) (ARanking rank) (ATimestamp ts1) (AUpdates us)  =
+  maybe (property Discard) checkTTL
+  $ Cache.insert ts0 k ttl_ crs rank rcache
+  where
+    rcache = foldUpdates (removeKeyUpdates k us) Cache.empty  -- 挿入する Key を除去
+    checkTTL ins =
+      case map DNS.rrttl . fst <$> Cache.lookup ts1 (toDomain dom) typ cls ins of
+        Nothing    ->  life === Nothing
+        Just ttls  ->  Just ttls === (replicate (length ttls) <$> life)
+      where
+        life = Cache.alive ts1 (ts0 <+ ttl_)
+
+---
+
+-- ranking
+
+rankingOrdered :: ACR2 -> ATTL -> ATTL ->  ARankOrds -> AUpdates -> Property
+rankingOrdered (ACR2 (k@(Key dom typ cls), (crs1, crs2))) (ATTL ttl1) (ATTL ttl2) (ARankOrds (r1, r2)) (AUpdates us) =
+  maybe (property False) id action
+  where
+    rcache = foldUpdates (removeKeyUpdates k us) Cache.empty  -- 挿入する Key を除去
+    action = do
+      c2 <- Cache.insert ts0 k ttl2 crs2 r2 rcache
+      c1 <- Cache.insert ts0 k ttl1 crs1 r1 c2
+      (rrs, rank) <- Cache.lookup ts0 (toDomain dom) typ cls c1
+      return $ rrs === extractRRSet k ttl1 crs1 .&&. rank === r1
+
+rankingNotOrdered :: ACR2 -> ATTL -> ATTL ->  ARankOrdsCo -> AUpdates -> Property
+rankingNotOrdered (ACR2 (k, (crs1, crs2))) (ATTL ttl1) (ATTL ttl2) (ARankOrdsCo (r1, r2)) (AUpdates us) =
+  action === Nothing
+  where
+    rcache = foldUpdates (removeKeyUpdates k us) Cache.empty  -- 挿入する Key を除去
+    action = do
+      c2 <- Cache.insert ts0 k ttl2 crs2 r2 rcache
+      _  <- Cache.insert ts0 k ttl1 crs1 r1 c2
+      pure ()
+
+---
+
+-- expires
+
+expiresAlives :: AUpdates -> ATimestamp -> Property
+expiresAlives (AUpdates us) (ATimestamp ts1) =
+  maybe (property Discard) checkSize
+  $ Cache.expires ts1 cache
+  where
+    checkSize ex =
+      Cache.size ex
+      ===
+      length
+      [ k | (k, ts) <- Cache.dumpKeys cache, Just _  <- [Cache.alive ts1 ts] ]
+    cache = foldUpdates (removeExpiresUpdates us) Cache.empty
+
+expiresMaxEOL :: AUpdates -> Property
+expiresMaxEOL (AUpdates us) =
+  maybe (property Discard) (=== 0) $ do
+  mx <- maxEOL
+  c  <- Cache.expires mx cache
+  return $ Cache.size c
+  where
+    cache = foldUpdates us Cache.empty
+    eol :: (Timestamp, Update) -> Maybe Timestamp
+    eol (ts, I _ ttl _)  =  Just $ ts <+ ttl
+    eol ( _,  E)         =  Nothing
+    maxEOL = case mapMaybe eol us of
+      []        ->  Nothing
+      es@(_:_)  ->  Just $ maximum es
+
+-----
+
+props :: [Property]
+props =
+  [ nprop "RRSet - take nothing"            rrsetTakeNothing
+  , nprop "RRSet - extract . take is just"  rrsetExtractTake
+
+  , nprop "size - empty"                    sizeEmpty
+  , nprop "size - consistent"               sizeConsistent
+  , nprop "size - new inserted"             sizeNewInserted
+  , nprop "size - inserted"                 sizeInserted
+  , nprop "size - expire1 with min-key"     sizeExpire1MinKey
+
+  , nprop "lookup - empty"                  lookupEmpty
+  , nprop "lookup - new inserted"           lookupNewInserted
+  , nprop "lookup - inserted"               lookupInserted
+  , nprop "lookup - ttl"                    lookupTTL
+
+  , nprop "ranking - ordered"               rankingOrdered
+  , nprop "ranking - not ordered"           rankingNotOrdered
+
+  , nprop "expires - alives"                expiresAlives
+  , nprop "expires - with max EOL"          expiresMaxEOL
+  ]
+  where
+    nprop name = counterexample ("prop: " ++ name) . label name
+
+run :: IO ()
+run = mapM_ quickCheck props
+
+-----

--- a/test/cache.hs
+++ b/test/cache.hs
@@ -1,0 +1,4 @@
+import CacheProp (run)
+
+main :: IO ()
+main = run


### PR DESCRIPTION
add data structure and interfaces to cache RRSet with ranking

- [x] cache RRSet with consistent TTL.
- [x] test properties for cache.
- [x] ranking implementation. get section RRs with rank.
- [x] test for ranking.