### PR TITLE
do cache and lookup cache while iterative query

### DIFF
--- a/dns-resolver.cabal
+++ b/dns-resolver.cabal
@@ -20,7 +20,9 @@ extra-source-files:  CHANGELOG.md
 library
   exposed-modules:
                        DNSC.Iterative
+                       DNSC.UpdateCache
                        DNSC.Cache
+                       DNSC.Log
 
   other-modules:
                        DNSC.RootServers

--- a/qtest/QuerySpec.hs
+++ b/qtest/QuerySpec.hs
@@ -92,6 +92,10 @@ spec = describe "query" $ do
     printQueryError result
     isRight result `shouldBe` True
 
+  it "reply - a accumulated via cname" $ do
+    result <- runReply "media-router-aol1.prod.media.yahoo.com." A 0
+    maybe 0 (length . DNS.answer) result `shouldSatisfy` (> 1)
+
   it "reply - txt via cname" $ do
     result <- runReply "porttest.dns-oarc.net." TXT 0
     maybe [] DNS.answer result `shouldSatisfy` (not . null)

--- a/qtest/QuerySpec.hs
+++ b/qtest/QuerySpec.hs
@@ -87,6 +87,11 @@ spec = describe "query" $ do
     let Right msg = result
     length (DNS.answer msg) `shouldSatisfy` (> 0)
 
+  it "query - a via cname" $ do
+    result <- runQuery "clients4.google.com." A
+    printQueryError result
+    isRight result `shouldBe` True
+
   it "reply - txt via cname" $ do
     result <- runReply "porttest.dns-oarc.net." TXT 0
     maybe [] DNS.answer result `shouldSatisfy` (not . null)

--- a/qtest/QuerySpec.hs
+++ b/qtest/QuerySpec.hs
@@ -3,6 +3,7 @@ module QuerySpec where
 import Test.Hspec
 
 import Data.Either (isRight)
+import Data.String (fromString)
 import Network.DNS (TYPE(NS, A, AAAA, MX, CNAME, TXT))
 import qualified Network.DNS as DNS
 import System.Environment (lookupEnv)
@@ -17,8 +18,8 @@ spec = describe "query" $ do
       runQuery1 n ty = runDNSQuery (query1 n ty) cxt
       runQuery n ty = runDNSQuery (query n ty) cxt
       runReply n ty ident = do
-        e <- runDNSQuery (reply n ty) cxt
-        return $ replyMessage e ident
+        e <- runDNSQuery (reply n ty True) cxt
+        return $ replyMessage e ident [DNS.Question (fromString n) ty]
 
   let printQueryError :: Show e => Either e a -> IO ()
       printQueryError = either (putStrLn . ("    QueryError: " ++) . show) (const $ pure ())

--- a/qtest/QuerySpec.hs
+++ b/qtest/QuerySpec.hs
@@ -72,6 +72,13 @@ spec = describe "query" $ do
     let Right msg = result
     length (DNS.answer msg) `shouldSatisfy` (> 0)
 
+  it "query1 - cname with nx" $ do
+    result <- runQuery1 "media-router-aol1.prod.media.yahoo.com." CNAME
+    printQueryError result
+    isRight result `shouldBe` True
+    let Right msg = result
+    length (DNS.answer msg) `shouldSatisfy` (> 0)
+
   it "query - cname" $ do
     result <- runQuery "porttest.dns-oarc.net." CNAME
     printQueryError result

--- a/src/DNSC/Iterative.hs
+++ b/src/DNSC/Iterative.hs
@@ -238,7 +238,8 @@ query_ n typ = do
 
   -- TODO: CNAME 解決の回数制限
   let resolveCNAME cn = do
-        when (any ((== typ) . rrtype) $ DNS.answer msg) $ throwDnsError DNS.UnexpectedRDATA  -- CNAME と目的の TYPE が同時に存在した場合はエラー
+        when (any ((&&) <$> (== bn) . rrname <*> (== typ) . rrtype) $ DNS.answer msg)  $
+          throwDnsError DNS.UnexpectedRDATA  -- CNAME と目的の TYPE が同時に存在した場合はエラー
         query_ (B8.unpack cn) typ
 
   maybe

--- a/src/DNSC/Log.hs
+++ b/src/DNSC/Log.hs
@@ -1,0 +1,20 @@
+module DNSC.Log (
+  new,
+  ) where
+
+import Control.Concurrent (forkIO)
+import Control.Concurrent.Chan (newChan, readChan, writeChan)
+import Control.Monad (void, forever, when)
+import System.IO (hSetBuffering, stdout, BufferMode (LineBuffering))
+
+new :: Bool -> IO (String -> IO ())
+new trace = do
+  when trace $ hSetBuffering stdout LineBuffering
+
+  logQ <- newChan
+  let flush1 = putStr =<< readChan logQ
+  void $ forkIO $ forever flush1
+
+  let putLog = when trace . writeChan logQ
+
+  return putLog

--- a/src/DNSC/UpdateCache.hs
+++ b/src/DNSC/UpdateCache.hs
@@ -1,0 +1,64 @@
+module DNSC.UpdateCache (
+  newCache,
+  ) where
+
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Concurrent.Chan (newChan, readChan, writeChan)
+import Control.Monad (void, forever)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Time (UTCTime, getCurrentTime)
+
+import Network.DNS (TTL, Domain, TYPE, CLASS, ResourceRecord)
+
+import DNSC.Cache (Cache, Key, Val, CRSet, Ranking)
+import qualified DNSC.Cache as Cache
+
+data Update
+  = I Key TTL CRSet Ranking
+  | E
+  deriving Show
+
+runUpdate :: UTCTime -> Update -> Cache -> Maybe Cache
+runUpdate t u = case u of
+  I k ttl crs rank -> Cache.insert t k ttl crs rank
+  E                -> Cache.expires t
+
+type Lookup = Domain -> TYPE -> CLASS -> IO (Maybe ([ResourceRecord], Ranking))
+type Insert = Key -> TTL -> CRSet -> Ranking -> IO ()
+type Dump = IO [(Key, (UTCTime, Val))]
+
+newCache :: (String -> IO ()) -> IO (Lookup, Insert, Dump)
+newCache putLog = do
+  let putLn = putLog . (++ "\n")
+  cacheRef <- newIORef Cache.empty
+  updateQ <- newChan
+
+  let update1 = do   -- step of single update theard
+        (ts, u) <- readChan updateQ
+        cache <- readIORef cacheRef
+        let updateRef c = do
+              writeIORef cacheRef c
+              case u of
+                I {}  ->  return ()
+                E     ->  putLn $ show ts ++ ": some records expired: size = " ++ show (Cache.size c)
+        maybe (pure ()) updateRef $ runUpdate ts u cache
+  void $ forkIO $ forever update1
+
+  let expires1 = do
+        threadDelay $ 1000 * 1000
+        writeChan updateQ =<< (,) <$> getCurrentTime <*> pure E
+  void $ forkIO $ forever expires1
+
+  let lookup_ dom typ cls = do
+        cache <- readIORef cacheRef
+        ts <- getCurrentTime
+        return $ Cache.lookup ts dom typ cls cache
+
+      insert k ttl crs rank =
+        writeChan updateQ =<< (,) <$> getCurrentTime <*> pure (I k ttl crs rank)
+
+      dump = do
+        cache <- readIORef cacheRef
+        return $ Cache.dump cache
+
+  return (lookup_, insert, dump)


### PR DESCRIPTION
use cached data and update cache, during iterative query.

- [x] get sections from DNSMessage and cache them.
- [x] add lookupCache interface and apply.
- [x] build reply DNSMessage using iterative query result.
- [x] action to update cache structure.
- [x] logging queue and thread for multi-context logging.
