### PR TITLE
Cache current time every second

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,11 @@
+
+packages:
+         ./
+
+source-repository-package
+        type: git
+        location: https://github.com/khibino/dns.git
+        tag: 4.0.1-extended-lookup
+
+package dns-resolver
+        ghc-options: -DEXTENDED_LOOKUP=1

--- a/dns-resolver.cabal
+++ b/dns-resolver.cabal
@@ -23,6 +23,7 @@ library
                        DNSC.Iterative
                        DNSC.UpdateCache
                        DNSC.Cache
+                       DNSC.TimeCache
                        DNSC.Log
 
   other-modules:
@@ -37,6 +38,7 @@ library
                      , bytestring
                      , containers
                      , transformers
+                     , time
 
                      -- other packages
                      , random
@@ -44,7 +46,6 @@ library
                      -- dns packages
                      , async
                      , network
-                     , hourglass
                      , psqueues
                      , iproute
                      , dns

--- a/qtest/QuerySpec.hs
+++ b/qtest/QuerySpec.hs
@@ -11,13 +11,15 @@ import qualified Network.DNS as DNS
 import System.Environment (lookupEnv)
 
 import qualified DNSC.UpdateCache as UCache
+import qualified DNSC.TimeCache as TimeCache
 import DNSC.Iterative (newContext, runDNSQuery, replyMessage, reply, query, query1, iterative, rootNS)
 
 spec :: Spec
 spec = describe "query" $ do
   disableV6NS <- runIO $ maybe False ((== "1") . take 1) <$> lookupEnv "DISABLE_V6_NS"
-  (ucache, _quit) <- runIO $ UCache.new (\_ _ -> pure ())
-  cxt <- runIO $ newContext (\_ _ -> pure ()) disableV6NS ucache
+  (tcache, _quitT) <- runIO TimeCache.new
+  (ucache, _quit) <- runIO $ UCache.new (\_ _ -> pure ()) tcache
+  cxt <- runIO $ newContext (\_ _ -> pure ()) disableV6NS ucache tcache
   let runIterative ns n = runDNSQuery (iterative ns n) cxt
       runQuery1 n ty = runDNSQuery (query1 n ty) cxt
       runQuery n ty = runDNSQuery (query n ty) cxt

--- a/src/DNSC/TimeCache.hs
+++ b/src/DNSC/TimeCache.hs
@@ -1,0 +1,40 @@
+module DNSC.TimeCache (
+  new,
+  none,
+  ) where
+
+import Control.Concurrent (threadDelay)
+import Data.Int (Int64)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Time (defaultTimeLocale, formatTime, getCurrentTimeZone, utcToZonedTime)
+import Data.Time.Clock.System (SystemTime (..), getSystemTime, systemToUTCTime)
+
+import DNSC.Concurrent (forkLoop)
+
+
+new :: IO ((IO Int64, IO ShowS), IO ())
+new = do
+  secRef <- newIORef 0
+  formatRef <- newIORef mempty
+
+  let step = do
+        t <- getSystemTime  {- calls clock_gettime in x86-64 linux -}
+        zt <- utcToZonedTime <$> getCurrentTimeZone <*> pure (systemToUTCTime t)
+        let seconds = systemSeconds t
+            fstring = (formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S %Z" zt ++) {- adjust to that the Log module uses String -}
+            intervalUSec = 1 * 1000 * 1000 - fromIntegral (systemNanoseconds t `quot` 1000)
+        writeIORef secRef seconds
+        writeIORef formatRef fstring
+        threadDelay intervalUSec
+
+  quit <- forkLoop step
+
+  return ((readIORef secRef, readIORef formatRef), quit)
+
+-- no caching
+none :: (IO Int64, IO ShowS)
+none =
+  (systemSeconds <$> getSystemTime,
+   (++) . formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S %Z" <$> getUTC)
+  where
+    getUTC = utcToZonedTime <$> getCurrentTimeZone <*> fmap systemToUTCTime getSystemTime

--- a/src/DNSC/UpdateCache.hs
+++ b/src/DNSC/UpdateCache.hs
@@ -6,6 +6,7 @@ module DNSC.UpdateCache (
 -- GHC packages
 import Control.Concurrent (threadDelay)
 import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Int (Int64)
 
 -- dns packages
 import Network.DNS (TTL, Domain, TYPE, CLASS, ResourceRecord)
@@ -13,13 +14,15 @@ import Network.DNS (TTL, Domain, TYPE, CLASS, ResourceRecord)
 -- this package
 import DNSC.Concurrent (forkLoop, forkConsumeQueue)
 import qualified DNSC.Log as Log
-import DNSC.Cache (Cache, Key, CRSet, Ranking, Timestamp, getTimestamp)
+import DNSC.Cache (Cache, Key, CRSet, Ranking)
 import qualified DNSC.Cache as Cache
 
 data Update
   = I Key TTL CRSet Ranking
   | E
   deriving Show
+
+type Timestamp = Int64
 
 runUpdate :: Timestamp -> Update -> Cache -> Maybe Cache
 runUpdate t u = case u of
@@ -29,33 +32,34 @@ runUpdate t u = case u of
 type Lookup = Domain -> TYPE -> CLASS -> IO (Maybe ([ResourceRecord], Ranking))
 type Insert = Key -> TTL -> CRSet -> Ranking -> IO ()
 
-new :: (Log.Level -> [String] -> IO ()) -> IO ((Lookup, Insert, IO Cache), IO ())
-new putLines = do
+new :: (Log.Level -> [String] -> IO ()) -> (IO Timestamp, IO ShowS)
+    -> IO ((Lookup, Insert, IO Cache), IO ())
+new putLines (getSec, getTimeStr) = do
   let putLn level = putLines level . (:[])
   cacheRef <- newIORef Cache.empty
 
-  let update1 (ts, u) = do   -- step of single update theard
+  let update1 (ts, tstr, u) = do   -- step of single update theard
         cache <- readIORef cacheRef
         let updateRef c = do
               writeIORef cacheRef c
               case u of
                 I {}  ->  return ()
-                E     ->  putLn Log.NOTICE $ show ts ++ ": some records expired: size = " ++ show (Cache.size c)
+                E     ->  putLn Log.NOTICE $ tstr $ ": some records expired: size = " ++ show (Cache.size c)
         maybe (pure ()) updateRef $ runUpdate ts u cache
   (enqueueU, quitU) <- forkConsumeQueue update1
 
   let expires1 = do
         threadDelay $ 1000 * 1000
-        enqueueU =<< (,) <$> getTimestamp <*> pure E
+        enqueueU =<< (,,) <$> getSec <*> getTimeStr <*> pure E
   quitE <- forkLoop expires1
 
   let lookup_ dom typ cls = do
         cache <- readIORef cacheRef
-        ts <- getTimestamp
+        ts <- getSec
         return $ Cache.lookup ts dom typ cls cache
 
       insert k ttl crs rank =
-        enqueueU =<< (,) <$> getTimestamp <*> pure (I k ttl crs rank)
+        enqueueU =<< (,,) <$> getSec <*> getTimeStr <*> pure (I k ttl crs rank)
 
   return ((lookup_, insert, readIORef cacheRef), quitE *> quitU)
 

--- a/test/CacheProp.hs
+++ b/test/CacheProp.hs
@@ -12,6 +12,7 @@ import Control.Monad (unless)
 import Data.Maybe (mapMaybe)
 import Data.List (sort)
 import Data.Char (ord)
+import Data.Int (Int64)
 import Data.ByteString.Short (ShortByteString)
 import qualified Data.ByteString.Short as Short
 import Network.DNS (TYPE (..), TTL)
@@ -19,8 +20,9 @@ import qualified Network.DNS as DNS
 import System.IO.Unsafe (unsafePerformIO)
 import System.Exit (exitFailure)
 
+import qualified DNSC.TimeCache as TimeCache
 import DNSC.Cache
-  (Cache, Key (Key), Val (Val), CRSet (..), Timestamp, (<+), getTimestamp,
+  (Cache, Key (Key), Val (Val), CRSet (..), (<+),
    Ranking, rankAuthAnswer, rankAnswer, rankAdditional,
    takeRRSet, extractRRSet)
 import qualified DNSC.Cache as Cache
@@ -77,8 +79,10 @@ nsList =
   [ "ns1.example.com.", "ns2.example.com.", "ns3.example.com."
   , "ns4.example.com.", "ns5.example.com." ]
 
+type Timestamp = Int64
+
 ts0 :: Timestamp
-ts0 = unsafePerformIO getTimestamp
+ts0 = unsafePerformIO $ fst TimeCache.none
 {-# NOINLINE ts0 #-}
 
 -----


### PR DESCRIPTION
Cache the current time every second and use that time to decode packets and manage the cache.

- [x] thread to cache timestamp
- [x] decode query result with cached timestamp
- [x] decode request with cached timestamp
- [x] manage cache using cached timestamp
