### PR TITLE
expiration on insert

### DIFF
--- a/src/DNSC/Cache.hs
+++ b/src/DNSC/Cache.hs
@@ -194,11 +194,11 @@ insert now k@(Key dom typ cls) ttl crs rank cache@(Cache c xsz) =
           Just $ Cache (PSQ.insert k eol (Val crs rank) deleted) xsz
 
 expires :: Timestamp -> Cache -> Maybe Cache
-expires now (Cache c xsz)
-  | null exs   =  Nothing
-  | otherwise  =  Just $ Cache result xsz
-  where
-    (exs, result) = PSQ.atMostView now c
+expires now (Cache c xsz) =
+  case PSQ.findMin c of
+    Just (_, eol, _) | eol <= now ->  Just $ Cache (snd $ PSQ.atMostView now c) xsz
+                     | otherwise  ->  Nothing
+    Nothing                       ->  Nothing
 
 alive :: Timestamp -> Timestamp -> Maybe TTL
 alive now eol = do

--- a/src/DNSC/UpdateCache.hs
+++ b/src/DNSC/UpdateCache.hs
@@ -30,9 +30,10 @@ data Update
   deriving Show
 
 runUpdate :: Timestamp -> Update -> Cache -> Maybe Cache
-runUpdate t u = case u of
-  I k ttl crs rank -> Cache.insert t k ttl crs rank
-  E                -> Cache.expires t
+runUpdate t u cache = case u of
+  I k ttl crs rank -> maybe (insert cache) insert $ Cache.expires t cache {- expires before insert -}
+    where insert = Cache.insert t k ttl crs rank
+  E                -> Cache.expires t cache
 
 type Lookup = Domain -> TYPE -> CLASS -> IO (Maybe ([ResourceRecord], Ranking))
 type Insert = Key -> TTL -> CRSet -> Ranking -> IO ()

--- a/src/DNSC/UpdateCache.hs
+++ b/src/DNSC/UpdateCache.hs
@@ -62,7 +62,7 @@ new putLines (getSec, getTimeStr) maxCacheSize = do
     return (forever body, writeQueue inQ, (,) <$> Queue.readSize inQ <*> pure (Queue.maxSize inQ))
 
   let expires1 = do
-        threadDelay $ 1000 * 1000
+        threadDelay $ 1800 * 1000 * 1000  -- when there is no insert for a long time
         enqueueU =<< (,,) <$> getSec <*> getTimeStr <*> pure E
 
       expireEvsnts = forever body


### PR DESCRIPTION
resolves #20 

- [x] call findMin first in `expires` to benefit from the constant time without expire
- [x] call `expires` before `insert`
